### PR TITLE
Update CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           name: Build application
           command: |
-            yarn build
+            ECW_ENV=dev yarn build
       - save_cache:
           key: node-cache-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:


### PR DESCRIPTION
yarn build したときに ECW_ENV 環境変数を付与しないと開発環境が動作しないので、取り急ぎ追加しました
根本的な修正は別 PR で出す予定です・・・テストが通れば・・・