### PR TITLE
Fix deprecation warning for String based operatators

### DIFF
--- a/backend/middleware/sequelize.js
+++ b/backend/middleware/sequelize.js
@@ -10,7 +10,6 @@ const sequelize = new Sequelize(
   {
     host: config.db.host,
     dialect: 'postgres',
-    operatorsAliases: false,
     pool: {
       max: config.db.max,
       min: 0,


### PR DESCRIPTION
Fix sequelize deprecation warning
  ```
(node:51) [SEQUELIZE0004] DeprecationWarning: A boolean value was passed to options.operatorsAliases. This is a no-op with v5 and should be removed.
  ```

ref: https://github.com/sequelize/sequelize/issues/8417